### PR TITLE
ci: Set timeout for GitHub Workflow

### DIFF
--- a/.github/workflows/elixir_checks.yml
+++ b/.github/workflows/elixir_checks.yml
@@ -5,6 +5,7 @@ jobs:
   checks:
     name: Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - name: Set up Elixir

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: amannn/action-semantic-pull-request@v3.4.1
         env:

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Because of the limit of GitHub Workflow is set to 2000min per month, we nee to block all 6 hours workflow  that suck all our time.
To do this, I just add `timeout-minutes: 10` (Or if Workflow is longer than 10 minutes, I set to the max duration + 25%).

That allow us to keep going with the Free GitHub Organisation plan.