### PR TITLE
fix: Fix types and get_widget params

### DIFF
--- a/lib/adapter_behavior.ex
+++ b/lib/adapter_behavior.ex
@@ -4,11 +4,24 @@ defmodule ApplicationRunner.AdapterBehavior do
   """
   alias ApplicationRunner.{EnvState, SessionState}
 
-  @callback get_manifest(EnvState.t()) :: {:ok, map()} | {:error, term()}
-  @callback get_widget(String.t(), map(), map()) :: {:ok, map()} | {:error, map()}
-  @callback run_listener(EnvState.t(), String.t(), map(), map(), map()) ::
-              {:ok, map()} | {:error, map()}
-  @callback get_data(SessionState.t()) :: {:ok, map()} | {:error, atom()}
-  @callback save_data(SessionState.t(), map()) :: :ok | {:error, atom()}
-  @callback on_ui_changed(SessionState.t(), {:ui, map()} | {:patches, list(map())}) :: :ok
+  @type widget() :: map()
+  @type manifest() :: map()
+  @type data() :: map()
+  @type props() :: map()
+  @type event() :: map()
+  @type reason() :: atom()
+  @type ui() :: map()
+  @type patches() :: list(map())
+  @type code() :: String.t()
+  @type action() :: String.t()
+  @type widget_name() :: String.t()
+
+  @callback get_manifest(EnvState.t()) :: {:ok, manifest()} | {:error, reason()}
+  @callback get_widget(EnvState.t(), widget_name(), data(), props()) ::
+              {:ok, widget()} | {:error, reason()}
+  @callback run_listener(EnvState.t(), action(), data(), props(), event()) ::
+              {:ok, data()} | {:error, reason()}
+  @callback get_data(SessionState.t()) :: {:ok, data()} | {:error, reason()}
+  @callback save_data(SessionState.t(), data()) :: :ok | {:error, reason()}
+  @callback on_ui_changed(SessionState.t(), {:ui, ui()} | {:patches, patches()}) :: :ok
 end

--- a/lib/adapter_handler.ex
+++ b/lib/adapter_handler.ex
@@ -6,13 +6,13 @@ defmodule ApplicationRunner.AdapterHandler do
   require Logger
 
   @behaviour ApplicationRunner.AdapterBehavior
-  defdelegate get_manifest(app),
+  defdelegate get_manifest(env_state),
     to: Application.compile_env!(:application_runner, :adapter)
 
-  defdelegate get_widget(app, widget, data),
+  defdelegate get_widget(env_state, widget, data, props),
     to: Application.compile_env!(:application_runner, :adapter)
 
-  defdelegate run_listener(app, action, data, props, event),
+  defdelegate run_listener(env_state, action, data, props, event),
     to: Application.compile_env!(:application_runner, :adapter)
 
   defdelegate get_data(session_state), to: Application.compile_env!(:application_runner, :adapter)

--- a/lib/environment/widget_cache.ex
+++ b/lib/environment/widget_cache.ex
@@ -26,9 +26,14 @@ defmodule ApplicationRunner.WidgetCache do
   @doc """
     Call the Adapter to get the Widget corresponding to the given the `WidgetContext`
   """
-  @spec get_widget(WidgetContext.t()) :: {:ok, map()} | {:error, any()}
-  def get_widget(%WidgetContext{} = current_widget) do
-    AdapterHandler.get_widget(current_widget.name, current_widget.data, current_widget.props)
+  @spec get_widget(EnvState.t(), WidgetContext.t()) :: {:ok, map()} | {:error, any()}
+  def get_widget(%EnvState{} = env_state, %WidgetContext{} = current_widget) do
+    AdapterHandler.get_widget(
+      env_state,
+      current_widget.name,
+      current_widget.data,
+      current_widget.props
+    )
   end
 
   @doc """
@@ -65,7 +70,7 @@ defmodule ApplicationRunner.WidgetCache do
         %UiContext{} = ui_context,
         %WidgetContext{} = current_widget
       ) do
-    with {:ok, widget} <- get_widget(current_widget),
+    with {:ok, widget} <- get_widget(env_state, current_widget),
          {:ok, component, new_app_context} <-
            build_component(env_state, widget, ui_context, current_widget) do
       {:ok, put_in(new_app_context.widgets_map[current_widget.id], component)}

--- a/test/support/application_runner_adapter.ex
+++ b/test/support/application_runner_adapter.ex
@@ -32,7 +32,7 @@ defmodule ApplicationRunner.ApplicationRunnerAdapter do
   def manifest_const, do: @manifest
 
   @impl true
-  def get_widget(name, data, props) do
+  def get_widget(_env_state, name, data, props) do
     GenServer.call(__MODULE__, {:get_widget, name, data, props})
   end
 


### PR DESCRIPTION
Add some type specifications to simplify usage (self-documented types).
Add EnvState to the `get_widget/4` function on adapter. This is necessary for the server.