### PR TITLE
feat: Add user_id in webhook migration

### DIFF
--- a/lib/contract/user.ex
+++ b/lib/contract/user.ex
@@ -7,9 +7,12 @@ defmodule ApplicationRunner.Contract.User do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias ApplicationRunner.Webhooks.Webhook
+
   @table_name Application.compile_env!(:application_runner, :lenra_user_table)
   schema @table_name do
     field(:email, :string)
+    has_many(:webhooks, Webhook, foreign_key: :uuid)
     timestamps()
   end
 

--- a/lib/webhooks/webhooks.ex
+++ b/lib/webhooks/webhooks.ex
@@ -9,7 +9,7 @@ defmodule ApplicationRunner.Webhooks.Webhook do
   alias ApplicationRunner.Contract.{Environment, User}
   alias ApplicationRunner.Webhooks.Webhook
 
-  @derive {Jason.Encoder, only: [:uuid, :action, :props, :environment_id]}
+  @derive {Jason.Encoder, only: [:uuid, :action, :props, :environment_id, :user_id]}
   @primary_key {:uuid, Ecto.UUID, autogenerate: true}
   schema "webhooks" do
     belongs_to(:environment, Environment)

--- a/lib/webhooks/webhooks.ex
+++ b/lib/webhooks/webhooks.ex
@@ -23,7 +23,7 @@ defmodule ApplicationRunner.Webhooks.Webhook do
 
   def changeset(webhook, params \\ %{}) do
     webhook
-    |> cast(params, [:action, :props])
+    |> cast(params, [:action, :props, :user_id])
     |> validate_required([:environment_id, :action])
     |> foreign_key_constraint(:environment_id)
     |> foreign_key_constraint(:user_id)
@@ -31,11 +31,6 @@ defmodule ApplicationRunner.Webhooks.Webhook do
 
   def new(env_id, params) do
     %Webhook{environment_id: env_id}
-    |> Webhook.changeset(params)
-  end
-
-  def new(env_id, user_id, params) do
-    %Webhook{environment_id: env_id, user_id: user_id}
     |> Webhook.changeset(params)
   end
 end

--- a/lib/webhooks/webhooks.ex
+++ b/lib/webhooks/webhooks.ex
@@ -6,13 +6,14 @@ defmodule ApplicationRunner.Webhooks.Webhook do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias ApplicationRunner.Contract.Environment
+  alias ApplicationRunner.Contract.{Environment, User}
   alias ApplicationRunner.Webhooks.Webhook
 
   @derive {Jason.Encoder, only: [:uuid, :action, :props, :environment_id]}
   @primary_key {:uuid, Ecto.UUID, autogenerate: true}
   schema "webhooks" do
     belongs_to(:environment, Environment)
+    belongs_to(:user, User)
 
     field(:action, :string)
     field(:props, :map)
@@ -23,12 +24,18 @@ defmodule ApplicationRunner.Webhooks.Webhook do
   def changeset(webhook, params \\ %{}) do
     webhook
     |> cast(params, [:action, :props])
-    |> validate_required([:action])
+    |> validate_required([:environment_id, :action])
     |> foreign_key_constraint(:environment_id)
+    |> foreign_key_constraint(:user_id)
   end
 
   def new(env_id, params) do
     %Webhook{environment_id: env_id}
+    |> Webhook.changeset(params)
+  end
+
+  def new(env_id, user_id, params) do
+    %Webhook{environment_id: env_id, user_id: user_id}
     |> Webhook.changeset(params)
   end
 end

--- a/priv/repo/migrations/20220920094700_add_user_id_in_webhooks.exs
+++ b/priv/repo/migrations/20220920094700_add_user_id_in_webhooks.exs
@@ -1,0 +1,9 @@
+defmodule ApplicationRunner.Repo.Migrations.AddUserIdInWebhooks do
+  use Ecto.Migration
+
+  def change do
+    alter table(:webhooks) do
+      add(:user_id, references(:users))
+    end
+  end
+end

--- a/test/webhooks/webhook_test.exs
+++ b/test/webhooks/webhook_test.exs
@@ -54,7 +54,7 @@ defmodule ApplicationRunner.Webhooks.WebhookTest do
       })
 
     assert webhook.valid? == false
-    assert [action: reason] = webhook.errors
+    assert [action: _reason] = webhook.errors
   end
 
   test "Insert Webhook with no props into database successfully" do
@@ -91,5 +91,9 @@ defmodule ApplicationRunner.Webhooks.WebhookTest do
 
     assert webhook.action == "test"
     assert webhook.user_id == user.id
+
+    preload_user = Repo.preload(webhook, :user)
+
+    assert preload_user.user.id == user.id
   end
 end

--- a/test/webhooks/webhook_test.exs
+++ b/test/webhooks/webhook_test.exs
@@ -81,7 +81,8 @@ defmodule ApplicationRunner.Webhooks.WebhookTest do
       User.new(%{"email" => "test@lenra.io"})
       |> Repo.insert!()
 
-    Webhook.new(env.id, user.id, %{
+    Webhook.new(env.id, %{
+      "user_id" => user.id,
       "action" => "test"
     })
     |> Repo.insert!()

--- a/test/webhooks/webhook_test.exs
+++ b/test/webhooks/webhook_test.exs
@@ -3,7 +3,7 @@ defmodule ApplicationRunner.Webhooks.WebhookTest do
 
   use ApplicationRunner.RepoCase
 
-  alias ApplicationRunner.Contract.Environment
+  alias ApplicationRunner.Contract.{Environment, User}
   alias ApplicationRunner.Repo
   alias ApplicationRunner.Webhooks.Webhook
 
@@ -70,5 +70,25 @@ defmodule ApplicationRunner.Webhooks.WebhookTest do
     webhook = Enum.at(Repo.all(Webhook), 0)
 
     assert webhook.action == "test"
+  end
+
+  test "Insert Webhook with user into database successfully" do
+    env =
+      Environment.new()
+      |> Repo.insert!()
+
+    user =
+      User.new(%{"email" => "test@lenra.io"})
+      |> Repo.insert!()
+
+    Webhook.new(env.id, user.id, %{
+      "action" => "test"
+    })
+    |> Repo.insert!()
+
+    webhook = Enum.at(Repo.all(Webhook), 0)
+
+    assert webhook.action == "test"
+    assert webhook.user_id == user.id
   end
 end


### PR DESCRIPTION
<!-- 
Link the related issue :
#42
-->
See Epic https://github.com/lenra-io/Lenra/issues/141

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [ ] I made my own code-review before requesting one

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->

We needed to make it possible for a webhook to be specific to a user instead of an environment, this could be useful if a webhook only needs to target a specific user and not trigger listeners outside of this user.

