### PR TITLE
fix: DevError not found in application-runner

### DIFF
--- a/lib/channels/app_channel.ex
+++ b/lib/channels/app_channel.ex
@@ -17,7 +17,8 @@ defmodule ApplicationRunner.AppChannel do
 
       alias LenraCommonWeb.ErrorHelpers
 
-      alias ApplicationRunner.Errors.{BusinessError, DevError, TechnicalError}
+      alias ApplicationRunner.Errors.{BusinessError, TechnicalError}
+      alias LenraCommon.Errors.DevError
 
       require Logger
 


### PR DESCRIPTION
The dialyzer is returning an error telling that the DevError does not exist. I wonder how could the CI be successful when merging previous work on that.

```console
lib/dev_tool/channels/app_channel.ex:5:unknown_function
Function ApplicationRunner.Errors.DevError.message/1 does not exist.
```