### PR TITLE
feat: query Exec checks

### DIFF
--- a/lib/environment/query_server.ex
+++ b/lib/environment/query_server.ex
@@ -304,10 +304,7 @@ defmodule ApplicationRunner.Environment.QueryServer do
             str
 
           [_, hex_id] ->
-            case BSON.ObjectId.decode!(hex_id) do
-              res ->
-                res
-            end
+            BSON.ObjectId.decode!(hex_id)
         end
 
       sub_map when is_map(sub_map) ->


### PR DESCRIPTION
<!-- 
Link the related issue :
#42
-->
https://github.com/lenra-io/application-runner/issues/289

## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I included unit tests that cover my changes
- [ ] I added/updated the documentation about my changes
- [ ] I made my own code-review before requesting one

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->
At runtime, when the query server receives a mongo_event, we check if the parsed query matches the document. In fact, we have a bug in this function, because in the parsed query, the Mongo identifiers are in the format: "ObjectId()" and the Mongo identifiers in the new document are in the format: BSON.ObjectId(), so the Exec cannot work if we have Mongo identifiers in the query.

## Technical highlight/advice
<!-- 
    Is there any complex point you want to highlight ?
    Do you need advice on specific point of your code ?
    Tell us here.
-->
