### PR TITLE
fix: Add content-length header for app requests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,10 @@ config :application_runner,
   lenra_user_table: "users",
   repo: ApplicationRunner.Repo,
   url: "localhost:4000",
-  env: "dev"
+  env: "dev",
+  faas_url: System.get_env("FAAS_URL", "https://openfaas-dev.lenra.me"),
+  faas_auth: System.get_env("FAAS_AUTH", "Basic YWRtaW46Z0Q4VjNHR1YxeUpS"),
+  faas_registry: System.get_env("FAAS_REGISTRY", "registry.gitlab.com/lenra/platform/lenra-ci")
 
 config :application_runner, :mongo,
   hostname: "localhost",

--- a/lib/services/application_services.ex
+++ b/lib/services/application_services.ex
@@ -8,6 +8,9 @@ defmodule ApplicationRunner.ApplicationServices do
 
   require Logger
 
+  @empty_body "{}"
+  @empty_body_length "2"
+
   defp get_http_context do
     base_url = Application.fetch_env!(:application_runner, :faas_url)
     auth = Application.fetch_env!(:application_runner, :faas_auth)
@@ -36,10 +39,6 @@ defmodule ApplicationRunner.ApplicationServices do
 
     url = "#{base_url}/function/#{function_name}"
 
-    headers = [
-      {"Content-Type", "application/json"} | base_headers
-    ]
-
     body =
       Jason.encode!(%{
         action: action,
@@ -47,6 +46,11 @@ defmodule ApplicationRunner.ApplicationServices do
         event: event,
         api: %{url: Application.fetch_env!(:application_runner, :url), token: token}
       })
+
+    headers = [
+      {"Content-Type", "application/json"},
+      {"Content-length", to_string(String.length(body))} | base_headers
+    ]
 
     Logger.debug("Call to Openfaas : #{function_name}")
 
@@ -80,8 +84,12 @@ defmodule ApplicationRunner.ApplicationServices do
     {base_url, base_headers} = get_http_context()
 
     url = "#{base_url}/function/#{function_name}"
-    headers = [{"Content-Type", "application/json"} | base_headers]
     body = Jason.encode!(%{view: view_name, data: data, props: props, context: context})
+
+    headers = [
+      {"Content-Type", "application/json"},
+      {"Content-length", to_string(String.length(body))} | base_headers
+    ]
 
     Logger.debug("Fetch application view \n#{url} : \n#{body}")
 
@@ -106,11 +114,15 @@ defmodule ApplicationRunner.ApplicationServices do
     {base_url, base_headers} = get_http_context()
 
     url = "#{base_url}/function/#{function_name}"
-    headers = [{"Content-Type", "application/json"} | base_headers]
+
+    headers = [
+      {"Content-Type", "application/json"},
+      {"Content-length", @empty_body_length} | base_headers
+    ]
 
     Logger.debug("Fetch application manifest \n#{url} : \n#{function_name}")
 
-    Finch.build(:post, url, headers)
+    Finch.build(:post, url, headers, @empty_body)
     |> Finch.request(AppHttp,
       receive_timeout: Application.fetch_env!(:application_runner, :manifest_timeout)
     )
@@ -137,8 +149,12 @@ defmodule ApplicationRunner.ApplicationServices do
 
     url = "#{base_url}/function/#{function_name}"
 
-    headers = [{"Content-Type", "application/json"} | base_headers]
     body = Jason.encode!(%{resource: resource})
+
+    headers = [
+      {"Content-Type", "application/json"},
+      {"Content-length", to_string(String.length(body))} | base_headers
+    ]
 
     Finch.build(:post, url, headers, body)
     |> Finch.stream(AppHttp, [], fn

--- a/test/controllers/colls_controller_test.exs
+++ b/test/controllers/colls_controller_test.exs
@@ -72,8 +72,9 @@ defmodule ApplicationRunner.CollsControllerTest do
 
       assert %{
                "message" => "Could not access mongo. Please try again later.",
-               "metadata" => %{"code" => 26, "message" => "ns not found"}
-             } = json_response(conn, 400)
+               "metadata" => %{"code" => 26, "message" => "ns not found"},
+               "reason" => "mongo_error"
+             } = json_response(conn, 500)
     end
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -58,9 +58,6 @@ defmodule ApplicationRunner.IntegrationTest do
 
     # Reset and setup mongo coll
     mongo_name = Environment.MongoInstance.get_full_name(em.env_id)
-    IO.inspect("-----------------------------------------")
-    IO.inspect(mongo_name)
-    IO.inspect("-----------------------------------------")
     Mongo.drop_collection(mongo_name, @coll)
 
     %{}

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -58,6 +58,9 @@ defmodule ApplicationRunner.IntegrationTest do
 
     # Reset and setup mongo coll
     mongo_name = Environment.MongoInstance.get_full_name(em.env_id)
+    IO.inspect("-----------------------------------------")
+    IO.inspect(mongo_name)
+    IO.inspect("-----------------------------------------")
     Mongo.drop_collection(mongo_name, @coll)
 
     %{}
@@ -117,6 +120,9 @@ defmodule ApplicationRunner.IntegrationTest do
 
           {:ok, %{"view" => name, "data" => data}} ->
             resp_view(logger_agent, conn, name, data)
+
+          {:ok, %{}} ->
+            resp_manifest(logger_agent, conn)
 
           {:error, _} ->
             resp_manifest(logger_agent, conn)


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## Description of the changes
Add content-length header to app requests because some servers needs it to read the body.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one


### I included unit tests that cover my changes
  - [ ] 👍 yes
  - [x] 🙅 no, because they aren't needed
  - [ ] 🙋 no, because I need help


### I added/updated the documentation about my changes

- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


## Technical highlight/advice
I added some missing configs in order to be able to run `mix` so I could test the fix with `mix run -e 'ApplicationRunner.ApplicationServices.fetch_view("fx", "main", %{}, %{}, %{})'`
