### PR TITLE
fix: context query params can now be present but empty

### DIFF
--- a/lib/channels/app_socket.ex
+++ b/lib/channels/app_socket.ex
@@ -8,11 +8,8 @@ defmodule ApplicationRunner.AppSocket do
       require Logger
       use Phoenix.Socket
       alias ApplicationRunner.AppSocket
-      alias ApplicationRunner.Contract.User
-      alias ApplicationRunner.Environment
-      alias ApplicationRunner.Errors.{BusinessError, TechnicalError}
+      alias ApplicationRunner.Errors.TechnicalError
       alias ApplicationRunner.Monitor
-      alias ApplicationRunner.Session
       alias ApplicationRunner.Telemetry
       alias LenraCommonWeb.ErrorHelpers
 
@@ -43,12 +40,17 @@ defmodule ApplicationRunner.AppSocket do
       # See `Phoenix.Token` documentation for examples in
       # performing token verification on connect.
       @impl true
-      def connect(params, socket, _connect_info) do
-        with {:ok, app_name, context} <- extract_params(params),
-             {:ok, user_id} <- @adapter_mod.resource_from_params(params),
-             :ok <- @adapter_mod.allow(user_id, app_name),
+      def connect(adapter_mod, params, socket, _connect_info) do
+        with {:ok, app_name, context} <- ApplicationRunner.AppSocket.extract_params(params),
+             {:ok, user_id} <- adapter_mod.resource_from_params(params),
+             :ok <- adapter_mod.allow(user_id, app_name),
              {:ok, env_metadata, session_metadata} <-
-               create_metadatas(user_id, app_name, context),
+               ApplicationRunner.AppSocket.create_metadatas(
+                 adapter_mod,
+                 user_id,
+                 app_name,
+                 context
+               ),
              start_time <- Telemetry.start(:app_session, session_metadata),
              {:ok, session_pid} <- Session.start_session(session_metadata, env_metadata) do
           Logger.notice("Joined app #{app_name} with params #{inspect(params)}")
@@ -80,72 +82,6 @@ defmodule ApplicationRunner.AppSocket do
         end
       end
 
-      defp extract_params(params) do
-        with {:ok, app_name} <- extract_appname(params) do
-          context = extract_context(params)
-          {:ok, app_name, context}
-        end
-      end
-
-      defp extract_context(params) do
-        case Map.get(params, "context", %{}) do
-          res when is_map(res) -> res
-          _not_map -> %{}
-        end
-      end
-
-      defp extract_appname(params) do
-        app_name = Map.get(params, "app")
-
-        if is_nil(app_name) do
-          BusinessError.no_app_found_tuple()
-        else
-          {:ok, app_name}
-        end
-      end
-
-      defp create_metadatas(user_id, app_name, context) do
-        session_id = Ecto.UUID.generate()
-
-        with function_name when is_bitstring(function_name) <-
-               @adapter_mod.get_function_name(app_name),
-             env_id <- @adapter_mod.get_env_id(app_name),
-             {:ok, session_token} <- create_session_token(env_id, session_id, user_id),
-             {:ok, env_token} <- create_env_token(env_id) do
-          # prepare the assigns to the session/environment
-          session_metadata = %Session.Metadata{
-            env_id: env_id,
-            session_id: session_id,
-            user_id: user_id,
-            function_name: function_name,
-            context: context,
-            token: session_token
-          }
-
-          env_metadata = %Environment.Metadata{
-            env_id: env_id,
-            function_name: function_name,
-            token: env_token
-          }
-
-          {:ok, env_metadata, session_metadata}
-        else
-          {:error, :forbidden} ->
-            {:error, BusinessError.forbidden()}
-
-          err ->
-            err
-        end
-      end
-
-      def create_env_token(env_id) do
-        AppSocket.do_create_env_token(env_id)
-      end
-
-      def create_session_token(env_id, session_id, user_id) do
-        AppSocket.do_create_session_token(env_id, session_id, user_id)
-      end
-
       # Socket id's are topics that allow you to identify all sockets for a given user:
       #
       #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
@@ -161,16 +97,53 @@ defmodule ApplicationRunner.AppSocket do
     end
   end
 
+  alias ApplicationRunner.Environment
+  alias ApplicationRunner.Errors.BusinessError
   alias ApplicationRunner.Guardian.AppGuardian
+  alias ApplicationRunner.Session
 
-  def do_create_env_token(env_id) do
+  def create_metadatas(adapter_mod, user_id, app_name, context) do
+    session_id = Ecto.UUID.generate()
+
+    with function_name when is_bitstring(function_name) <-
+           adapter_mod.get_function_name(app_name),
+         env_id <- adapter_mod.get_env_id(app_name),
+         {:ok, session_token} <- create_session_token(env_id, session_id, user_id),
+         {:ok, env_token} <- create_env_token(env_id) do
+      # prepare the assigns to the session/environment
+      session_metadata = %Session.Metadata{
+        env_id: env_id,
+        session_id: session_id,
+        user_id: user_id,
+        function_name: function_name,
+        context: context,
+        token: session_token
+      }
+
+      env_metadata = %Environment.Metadata{
+        env_id: env_id,
+        function_name: function_name,
+        token: env_token
+      }
+
+      {:ok, env_metadata, session_metadata}
+    else
+      {:error, :forbidden} ->
+        {:error, BusinessError.forbidden()}
+
+      err ->
+        err
+    end
+  end
+
+  def create_env_token(env_id) do
     with {:ok, token, _claims} <-
            AppGuardian.encode_and_sign(env_id, %{type: "env", env_id: env_id}) do
       {:ok, token}
     end
   end
 
-  def do_create_session_token(env_id, session_id, user_id) do
+  def create_session_token(env_id, session_id, user_id) do
     with {:ok, token, _claims} <-
            AppGuardian.encode_and_sign(session_id, %{
              type: "session",
@@ -178,6 +151,30 @@ defmodule ApplicationRunner.AppSocket do
              env_id: env_id
            }) do
       {:ok, token}
+    end
+  end
+
+  def extract_params(params) do
+    with {:ok, app_name} <- extract_appname(params) do
+      context = extract_context(params)
+      {:ok, app_name, context}
+    end
+  end
+
+  defp extract_context(params) do
+    case Map.get(params, "context", %{}) do
+      res when is_map(res) -> res
+      _not_map -> %{}
+    end
+  end
+
+  defp extract_appname(params) do
+    app_name = Map.get(params, "app")
+
+    if is_nil(app_name) do
+      BusinessError.no_app_found_tuple()
+    else
+      {:ok, app_name}
     end
   end
 end

--- a/lib/channels/app_socket.ex
+++ b/lib/channels/app_socket.ex
@@ -81,13 +81,26 @@ defmodule ApplicationRunner.AppSocket do
       end
 
       defp extract_params(params) do
+        with {:ok, app_name} <- extract_appname(params) do
+          context = extract_context(params)
+          {:ok, app_name, context}
+        end
+      end
+
+      defp extract_context(params) do
+        case Map.get(params, "context", %{}) do
+          res when is_map(res) -> res
+          _not_map -> %{}
+        end
+      end
+
+      defp extract_appname(params) do
         app_name = Map.get(params, "app")
-        context = Map.get(params, "context", %{})
 
         if is_nil(app_name) do
           BusinessError.no_app_found_tuple()
         else
-          {:ok, app_name, context}
+          {:ok, app_name}
         end
       end
 

--- a/lib/crons.ex
+++ b/lib/crons.ex
@@ -18,7 +18,7 @@ defmodule ApplicationRunner.Crons do
         function_name
       ) do
     with {:ok, token} <-
-           AppSocket.do_create_env_token(env_id),
+           AppSocket.create_env_token(env_id),
          {:ok, _pid} <-
            Environment.ensure_env_started(%Environment.Metadata{
              env_id: env_id,

--- a/test/controllers/colls_controller_test.exs
+++ b/test/controllers/colls_controller_test.exs
@@ -12,7 +12,7 @@ defmodule ApplicationRunner.CollsControllerTest do
 
     {:ok, env} = ApplicationRunner.Repo.insert(Contract.Environment.new(%{}))
 
-    token = ApplicationRunner.AppSocket.do_create_env_token(env.id) |> elem(1)
+    token = ApplicationRunner.AppSocket.create_env_token(env.id) |> elem(1)
 
     env_metadata = %Environment.Metadata{
       env_id: env.id,

--- a/test/controllers/docs_controller_test.exs
+++ b/test/controllers/docs_controller_test.exs
@@ -12,7 +12,7 @@ defmodule ApplicationRunner.DocsControllerTest do
 
     {:ok, env} = ApplicationRunner.Repo.insert(Contract.Environment.new(%{}))
 
-    token = ApplicationRunner.AppSocket.do_create_env_token(env.id) |> elem(1)
+    token = ApplicationRunner.AppSocket.create_env_token(env.id) |> elem(1)
 
     env_metadata = %Environment.Metadata{
       env_id: env.id,

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -77,7 +77,7 @@ defmodule ApplicationRunner.IntegrationTest do
         session_id: @session_id,
         function_name: @function_name,
         context: %{},
-        token: AppSocket.do_create_session_token(env.id, @session_id, user.id) |> elem(1)
+        token: AppSocket.create_session_token(env.id, @session_id, user.id) |> elem(1)
       }
     }
   end
@@ -87,7 +87,7 @@ defmodule ApplicationRunner.IntegrationTest do
       env_metadata: %Environment.Metadata{
         env_id: env.id,
         function_name: @function_name,
-        token: AppSocket.do_create_env_token(env.id) |> elem(1)
+        token: AppSocket.create_env_token(env.id) |> elem(1)
       }
     }
   end

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -14,7 +14,7 @@ defmodule ApplicationRunner.StorageTest do
 
   setup do
     {:ok, env} = Repo.insert(Environment.new())
-    token = ApplicationRunner.AppSocket.do_create_env_token(env.id) |> elem(1)
+    token = ApplicationRunner.AppSocket.create_env_token(env.id) |> elem(1)
 
     env_metadata = %Metadata{
       env_id: env.id,

--- a/test/webhooks/webhook_controller_test.exs
+++ b/test/webhooks/webhook_controller_test.exs
@@ -32,7 +32,7 @@ defmodule ApplicationRunner.Webhooks.ControllerTest do
     session_uuid = Ecto.UUID.generate()
 
     token =
-      ApplicationRunner.AppSocket.do_create_session_token(env.id, session_uuid, user.id)
+      ApplicationRunner.AppSocket.create_session_token(env.id, session_uuid, user.id)
       |> elem(1)
 
     session_metadata = %ApplicationRunner.Session.Metadata{
@@ -60,7 +60,7 @@ defmodule ApplicationRunner.Webhooks.ControllerTest do
   defp setup_env_token do
     {:ok, env} = ApplicationRunner.Repo.insert(Contract.Environment.new(%{}))
 
-    token = ApplicationRunner.AppSocket.do_create_env_token(env.id) |> elem(1)
+    token = ApplicationRunner.AppSocket.create_env_token(env.id) |> elem(1)
 
     env_metadata = %Environment.Metadata{
       env_id: env.id,

--- a/test/webhooks/webhook_services_test.exs
+++ b/test/webhooks/webhook_services_test.exs
@@ -10,7 +10,7 @@ defmodule ApplicationRunner.Webhooks.ServicesTest do
 
   setup do
     {:ok, env} = Repo.insert(Environment.new())
-    token = ApplicationRunner.AppSocket.do_create_env_token(env.id) |> elem(1)
+    token = ApplicationRunner.AppSocket.create_env_token(env.id) |> elem(1)
 
     env_metadata = %Metadata{
       env_id: env.id,


### PR DESCRIPTION

## Description of the changes
When using a custom client (react for example), sometimes an empty context "{}" in the websocket url query param is encoded as empty : `ws://localhost:4000/socket?context=&token=abcd`. 
This leads to wrong context parsing : `%{"context" => ""}` instead of `%{"context": %{}}`.

This PR fix the parser to avoid this.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one


### I included unit tests that cover my changes
  - [ ] 👍 yes
  - [x] 🙅 no, because they aren't needed
  - [ ] 🙋 no, because I need help


### I added/updated the documentation about my changes

- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed
